### PR TITLE
BREAKING: Fixes typo in method setting heartbeat interval

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -46,8 +46,8 @@ func Register(c component.Component) {
 	comps = append(comps, c)
 }
 
-// Set heartbeat time internal
-func SetHeartbeatInternal(d time.Duration) {
+// Set heartbeat time interval
+func SetHeartbeatInterval(d time.Duration) {
 	env.heartbeat = d
 }
 


### PR DESCRIPTION
This PullRequest fixes a typo in *interval* by renaming _SetHeartbeatInternal_ to _SetHeartbeatInterval_. This is a breaking change thus I don't know if we should keep backward compatibility or not.